### PR TITLE
docs: add pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr__bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr__bugfix.md
@@ -1,0 +1,41 @@
+# Bug Fix PR Template
+
+## Summary
+
+Provide a concise description of the bug and the fix.
+
+## Issue Link
+
+Link to the issue being addressed.
+
+## Root Cause Analysis
+
+Detail the root cause of the bug and how it was identified.
+
+## Changes
+
+Outline the changes made to fix the bug.
+
+## Impact
+
+Describe any implications this fix may have on other parts of the application.
+
+## Testing Strategy
+
+Explain how the fix has been tested to ensure the bug is resolved without introducing new issues.
+
+## Regression Risk
+
+Assess the risk of regression caused by this fix and steps taken to mitigate it.
+
+## Checklist
+
+- [ ] The fix has been locally tested
+
+- [ ] New unit tests have been added to prevent future regressions
+
+- [ ] The documentation has been updated if necessary
+
+## Additional Notes
+
+Any further information needed to understand the fix or its impact.

--- a/.github/PULL_REQUEST_TEMPLATE/pr__docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr__docs.md
@@ -1,0 +1,35 @@
+# Documentation Update PR Template
+
+## Summary
+
+Brief description of the documentation update and its purpose.
+
+## Areas Affected
+
+List the sections or pages of the documentation that are updated.
+
+## Details
+
+Provide detailed information about the changes made to the documentation.
+
+## Motivation
+
+Explain why these documentation changes are necessary.
+
+## Review Checklist
+
+- [ ] Spelling and grammar are correct
+
+- [ ] All links are working and correct
+
+- [ ] Documentation accurately reflects the current state of the project
+
+- [ ] Changes are clearly highlighted and easy to understand
+
+## Screenshots
+
+Include before and after screenshots for significant visual changes, if applicable.
+
+## Additional Notes
+
+Any other information that might be helpful for reviewers.

--- a/.github/PULL_REQUEST_TEMPLATE/pr__feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr__feature.md
@@ -1,0 +1,43 @@
+# Feature Addition PR Template
+
+## Summary
+
+Briefly describe the feature being introduced.
+
+## Rationale
+
+Explain the reasoning behind this feature and its benefits to the project.
+
+## Design Documentation
+
+Link to any design documents or diagrams relevant to this feature.
+
+## Changes
+
+List the major changes made in this pull request.
+
+## Impact
+
+Discuss any potential impacts this feature may have on existing functionalities.
+
+## Testing
+
+Describe how the feature has been tested, including both automated and manual testing strategies.
+
+## Screenshots/Video
+
+Include screenshots or video demonstrating the new feature, if applicable.
+
+## Checklist
+
+- [ ] Code follows the project's coding standards
+
+- [ ] Unit tests covering the new feature have been added
+
+- [ ] All existing tests pass
+
+- [ ] The documentation has been updated to reflect the new feature
+
+## Additional Notes
+
+Any additional information or context relevant to this PR.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please go to the `Preview` tab and select the appropriate sub-template:
+
+* [Feature PR Template](?expand=1&template=pr__feature.md)
+* [Bugfix PR Template](?expand=1&template=pr__bugfix.md)
+* [Documentation PR Template](?expand=1&template=pr__doc.md)


### PR DESCRIPTION
# Pull Request Templates

## Summary

Add pull request templates.

## Areas Affected

GitHub Pull Requests.

## Details

- `pr__feature.md` is a template for new features to the game.
- `pr__bugfix.md` is a template for patches that fix bugs and defects.
- `pr__docs.md` is a template for updates to documentation.
- `pull_request_template.md` is the default template which points to the other three templates.

## Motivation

Having templates ensures consistent PR messaging.

## Review Checklist

- [x] Spelling and grammar are correct

- [x] All links are working and correct

- [x] Documentation accurately reflects the current state of the project

- [x] Changes are clearly highlighted and easy to understand

## Screenshots

![A screenshot of a new Pull Request demonstrating that selecting the Preview tab allows you to choose the pull request template you would like to use.](https://github.com/user-attachments/assets/aeedc11a-5df3-40e0-9b50-bb6caea5d8b3)

## Additional Notes

N/A